### PR TITLE
Make `FlowYieldVaultsRequests` Solidity contract upgradeable

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "solidity/lib/openzeppelin-contracts"]
 	path = solidity/lib/openzeppelin-contracts
 	url = https://github.com/OpenZeppelin/openzeppelin-contracts
+[submodule "solidity/lib/openzeppelin-contracts-upgradeable"]
+	path = solidity/lib/openzeppelin-contracts-upgradeable
+	url = https://github.com/OpenZeppelin/openzeppelin-contracts-upgradeable

--- a/local/deploy_full_stack.sh
+++ b/local/deploy_full_stack.sh
@@ -153,12 +153,13 @@ DEPLOYMENT_OUTPUT=$(forge script ./solidity/script/DeployFlowYieldVaultsRequests
   --root ./solidity \
   --rpc-url "http://$RPC_URL" \
   --broadcast \
-  --legacy 2>&1)
+  --legacy \
+  --slow 2>&1)
 
 echo "$DEPLOYMENT_OUTPUT"
 
 # Extract the deployed contract address from the output
-FLOW_VAULTS_REQUESTS_CONTRACT=$(echo "$DEPLOYMENT_OUTPUT" | grep "FlowYieldVaultsRequests deployed at:" | sed 's/.*: //')
+FLOW_VAULTS_REQUESTS_CONTRACT=$(echo "$DEPLOYMENT_OUTPUT" | grep "FlowYieldVaultsRequests proxy deployed at:" | sed 's/.*: //')
 
 if [ -z "$FLOW_VAULTS_REQUESTS_CONTRACT" ]; then
   echo "❌ Failed to extract FlowYieldVaultsRequests contract address from deployment"

--- a/solidity/foundry.lock
+++ b/solidity/foundry.lock
@@ -13,5 +13,11 @@
       "name": "v5.5.0",
       "rev": "fcbae5394ae8ad52d8e580a3477db99814b9d565"
     }
+  },
+  "lib/openzeppelin-contracts-upgradeable": {
+    "tag": {
+      "name": "v5.6.1",
+      "rev": "7bf4727aacdbfaa0f36cbd664654d0c9e1dc52bf"
+    }
   }
 }

--- a/solidity/foundry.toml
+++ b/solidity/foundry.toml
@@ -3,12 +3,14 @@ src = "src"
 out = "out"
 libs = ["lib"]
 fs_permissions = [{ access = "read", path = "../env" }]
-solc_version = "0.8.20"
+solc_version = "0.8.24"
+evm_version = "cancun"
 optimizer = true
 optimizer_runs = 200
 via_ir = true
 remappings = [
-    "@openzeppelin/contracts/=lib/openzeppelin-contracts/contracts/"
+    "@openzeppelin/contracts/=lib/openzeppelin-contracts/contracts/",
+    "@openzeppelin/contracts-upgradeable/=lib/openzeppelin-contracts-upgradeable/contracts/"
 ]
 
 # See more config options https://github.com/foundry-rs/foundry/blob/master/crates/config/README.md#all-options

--- a/solidity/script/DeployFlowYieldVaultsRequests.s.sol
+++ b/solidity/script/DeployFlowYieldVaultsRequests.s.sol
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.20;
+pragma solidity 0.8.24;
 
 import {Script, console} from "forge-std/Script.sol";
+import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 import {FlowYieldVaultsRequests} from "../src/FlowYieldVaultsRequests.sol";
 
 /**
@@ -27,12 +28,18 @@ contract DeployFlowYieldVaultsRequests is Script {
         address wflowAddress = vm.envOr("WFLOW_ADDRESS", address(0));
 
         vm.startBroadcast(deployerPrivateKey);
+        FlowYieldVaultsRequests fyvImplementation = new FlowYieldVaultsRequests();
 
-        FlowYieldVaultsRequests flowYieldVaultsRequests = new FlowYieldVaultsRequests(coaAddress, wflowAddress);
-
+        ERC1967Proxy fyvProxy = new ERC1967Proxy(
+            address(fyvImplementation),
+            abi.encodeCall(FlowYieldVaultsRequests.initialize, (coaAddress, wflowAddress))
+        );
         vm.stopBroadcast();
 
-        console.log("FlowYieldVaultsRequests deployed at:", address(flowYieldVaultsRequests));
+        FlowYieldVaultsRequests flowYieldVaultsRequests = FlowYieldVaultsRequests(address(fyvProxy));
+
+        console.log("FlowYieldVaultsRequests proxy deployed at:", address(flowYieldVaultsRequests));
+        console.log("FlowYieldVaultsRequests implementation at:", address(fyvImplementation));
         console.log("Authorized COA:", coaAddress);
         console.log("WFLOW Address:", wflowAddress);
         console.log("Owner:", flowYieldVaultsRequests.owner());

--- a/solidity/script/FlowYieldVaultsYieldVaultOperations.s.sol
+++ b/solidity/script/FlowYieldVaultsYieldVaultOperations.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.20;
+pragma solidity 0.8.24;
 
 import {Script, console} from "forge-std/Script.sol";
 import {FlowYieldVaultsRequests} from "../src/FlowYieldVaultsRequests.sol";

--- a/solidity/src/FlowYieldVaultsRequests.sol
+++ b/solidity/src/FlowYieldVaultsRequests.sol
@@ -1,18 +1,14 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.20;
+pragma solidity 0.8.24;
 
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 import {
     SafeERC20
 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
-import {
-    ReentrancyGuard
-} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
-import {
-    Ownable2Step,
-    Ownable
-} from "@openzeppelin/contracts/access/Ownable2Step.sol";
+import "@openzeppelin/contracts/utils/ReentrancyGuardTransient.sol";
+import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 
 /**
  * @title FlowYieldVaultsRequests
@@ -37,7 +33,11 @@ import {
  *      precision than Cadence can represent, the worker rounds the bridged amount down to the nearest
  *      Cadence-representable quantity and refunds the remainder to claimableRefunds during completion.
  */
-contract FlowYieldVaultsRequests is ReentrancyGuard, Ownable2Step {
+contract FlowYieldVaultsRequests is
+    ReentrancyGuardTransient,
+    OwnableUpgradeable,
+    UUPSUpgradeable
+{
     using SafeERC20 for IERC20;
 
     // ============================================
@@ -110,7 +110,9 @@ contract FlowYieldVaultsRequests is ReentrancyGuard, Ownable2Step {
 
     /// @notice WFLOW (Wrapped FLOW) ERC20 token address
     /// @dev On Cadence side, WFLOW is automatically unwrapped to native FlowToken by FlowEVMBridge
-    address public immutable WFLOW;
+    ///      Set once in initialize(). Any future upgrade that introduces a setter must
+    ///      also migrate allowedTokens[oldWFLOW] → allowedTokens[newWFLOW].
+    address public WFLOW;
 
     /// @notice Sentinel value for "no yieldvault"
     /// @dev Uses type(uint64).max since valid yieldVaultIds can be 0
@@ -531,10 +533,17 @@ contract FlowYieldVaultsRequests is ReentrancyGuard, Ownable2Step {
     // Constructor
     // ============================================
 
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() {
+        _disableInitializers();
+    }
+
     /// @notice Initializes the contract with COA address and default configuration
     /// @param coaAddress Address of the authorized COA
     /// @param wflowAddress Address of the WFLOW (Wrapped FLOW) ERC20 token
-    constructor(address coaAddress, address wflowAddress) Ownable(msg.sender) {
+    function initialize(address coaAddress, address wflowAddress) public initializer {
+        __Ownable_init(msg.sender);
+
         if (coaAddress == address(0)) revert InvalidCOAAddress();
 
         authorizedCOA = coaAddress;
@@ -2001,4 +2010,6 @@ contract FlowYieldVaultsRequests is ReentrancyGuard, Ownable2Step {
             delete _requestIndexInUserArray[requestId];
         }
     }
+
+    function _authorizeUpgrade(address newImplementation) internal override onlyOwner {}
 }

--- a/solidity/test/FlowYieldVaultsRequests.t.sol
+++ b/solidity/test/FlowYieldVaultsRequests.t.sol
@@ -1,9 +1,10 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.20;
+pragma solidity 0.8.24;
 
 import "forge-std/Test.sol";
 import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import {ERC20Mock} from "@openzeppelin/contracts/mocks/token/ERC20Mock.sol";
+import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 import "../src/FlowYieldVaultsRequests.sol";
 
 contract TestERC20 is ERC20 {
@@ -31,8 +32,6 @@ contract MockDAI is ERC20 {
 }
 
 contract FlowYieldVaultsRequestsTestHelper is FlowYieldVaultsRequests {
-    constructor(address coaAddress, address wflowAddress) FlowYieldVaultsRequests(coaAddress, wflowAddress) {}
-
     function testRegisterYieldVaultId(uint64 yieldVaultId, address owner, address tokenAddress) external {
         validYieldVaultIds[yieldVaultId] = true;
         yieldVaultOwners[yieldVaultId] = owner;
@@ -46,6 +45,7 @@ contract FlowYieldVaultsRequestsTestHelper is FlowYieldVaultsRequests {
 
 contract FlowYieldVaultsRequestsTest is Test {
     FlowYieldVaultsRequestsTestHelper public c;
+    FlowYieldVaultsRequestsTestHelper public impl;
     ERC20Mock public wflow;
     ERC20Mock public tokenB;
     address user = makeAddr("user");
@@ -84,7 +84,14 @@ contract FlowYieldVaultsRequestsTest is Test {
         wflow.mint(user2, 100 ether);
         tokenB.mint(user, 100 ether);
         tokenB.mint(user2, 100 ether);
-        c = new FlowYieldVaultsRequestsTestHelper(coa, WFLOW);
+
+        impl = new FlowYieldVaultsRequestsTestHelper();
+        ERC1967Proxy fyvProxy = new ERC1967Proxy(
+            address(impl),
+            abi.encodeWithSignature("initialize(address,address)", coa, WFLOW)
+        );
+
+        c = FlowYieldVaultsRequestsTestHelper(address(fyvProxy));
         c.testRegisterYieldVaultId(42, user, NATIVE_FLOW);
 
         dai = new MockDAI();
@@ -725,8 +732,13 @@ contract FlowYieldVaultsRequestsTest is Test {
     }
 
     function test_Constructor_RevertZeroCOAAddress() public {
+        FlowYieldVaultsRequestsTestHelper fyvImpl = new FlowYieldVaultsRequestsTestHelper();
+
         vm.expectRevert(FlowYieldVaultsRequests.InvalidCOAAddress.selector);
-        new FlowYieldVaultsRequestsTestHelper(address(0), WFLOW);
+        new ERC1967Proxy(
+            address(fyvImpl),
+            abi.encodeWithSignature("initialize(address,address)", address(0), WFLOW)
+        );
     }
 
     function test_SetTokenConfig() public {
@@ -801,25 +813,16 @@ contract FlowYieldVaultsRequestsTest is Test {
     // OWNERSHIP TRANSFER
     // ============================================
 
-    function test_TransferOwnership_TwoStepProcess() public {
+    function test_TransferOwnership() public {
         address newOwner = makeAddr("newOwner");
         address originalOwner = c.owner();
 
-        // Step 1: Current owner initiates transfer
+        // Current owner initiates transfer
         vm.prank(originalOwner);
         c.transferOwnership(newOwner);
 
-        // Owner hasn't changed yet
-        assertEq(c.owner(), originalOwner);
-        assertEq(c.pendingOwner(), newOwner);
-
-        // Step 2: New owner accepts
-        vm.prank(newOwner);
-        c.acceptOwnership();
-
         // Now ownership is transferred
         assertEq(c.owner(), newOwner);
-        assertEq(c.pendingOwner(), address(0));
     }
 
     function test_TransferOwnership_RevertNotOwner() public {
@@ -828,24 +831,12 @@ contract FlowYieldVaultsRequestsTest is Test {
         c.transferOwnership(makeAddr("newOwner"));
     }
 
-    function test_AcceptOwnership_RevertNotPendingOwner() public {
-        vm.prank(c.owner());
-        c.transferOwnership(makeAddr("newOwner"));
-
-        vm.prank(user);
-        vm.expectRevert(abi.encodeWithSelector(OwnableUnauthorizedAccount.selector, user));
-        c.acceptOwnership();
-    }
-
     function test_TransferOwnership_NewOwnerHasAdminRights() public {
         address newOwner = makeAddr("newOwner");
         address originalOwner = c.owner();
 
         vm.prank(originalOwner);
         c.transferOwnership(newOwner);
-
-        vm.prank(newOwner);
-        c.acceptOwnership();
 
         // New owner can perform admin actions
         vm.prank(newOwner);
@@ -856,6 +847,100 @@ contract FlowYieldVaultsRequestsTest is Test {
         vm.prank(originalOwner);
         vm.expectRevert(abi.encodeWithSelector(OwnableUnauthorizedAccount.selector, originalOwner));
         c.setMaxPendingRequestsPerUser(50);
+    }
+
+    // ============================================
+    // CONTRACT UPGRADES
+    // ============================================
+
+    function test_UpgradeContract_RevertNotOwner() public {
+        vm.prank(user);
+        address newImplementation = makeAddr("newImplementation");
+        bytes memory data;
+
+        vm.expectRevert(abi.encodeWithSelector(
+            OwnableUnauthorizedAccount.selector,
+            user
+        ));
+        c.upgradeToAndCall(newImplementation, data);
+    }
+
+    function test_UpgradeContract() public {
+        FlowYieldVaultsRequestsTestHelper newImplementation = new FlowYieldVaultsRequestsTestHelper();
+        bytes memory data;
+
+        bytes32 slot = bytes32(0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc);
+        bytes32 value = vm.load(address(c), slot);
+        address currentImplementation = address(uint160(uint256(value)));
+        assertEq(currentImplementation, address(impl));
+
+        vm.prank(c.owner());
+        c.upgradeToAndCall(address(newImplementation), data);
+
+        value = vm.load(address(c), slot);
+        currentImplementation = address(uint160(uint256(value)));
+        assertEq(currentImplementation, address(newImplementation));
+    }
+
+    function test_UpgradeContract_RequestsPreserved() public {
+        vm.startPrank(user);
+        uint256 req1 = c.createYieldVault{value: 1 ether}(NATIVE_FLOW, 1 ether, VAULT_ID, STRATEGY_ID);
+        uint256 req2 = c.createYieldVault{value: 2 ether}(NATIVE_FLOW, 2 ether, VAULT_ID, STRATEGY_ID);
+        uint256 req3 = c.createYieldVault{value: 3 ether}(NATIVE_FLOW, 3 ether, VAULT_ID, STRATEGY_ID);
+        vm.stopPrank();
+
+        // Assert that the implementation contract has no requests,
+        // since the storage is in the Proxy contract.
+        assertEq(impl.getPendingRequestCount(), 0);
+        assertEq(c.getPendingRequestCount(), 3);
+
+        FlowYieldVaultsRequestsTestHelper newImplementation = new FlowYieldVaultsRequestsTestHelper();
+        bytes memory data;
+
+        vm.prank(c.owner());
+        c.upgradeToAndCall(address(newImplementation), data);
+
+        bytes32 slot = bytes32(0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc);
+        bytes32 value = vm.load(address(c), slot);
+        address currentImplementation = address(uint160(uint256(value)));
+        assertEq(currentImplementation, address(newImplementation));
+
+        // Assert that the new implementation contract has no requests,
+        // since the storage is in the Proxy contract.
+        assertEq(newImplementation.getPendingRequestCount(), 0);
+        assertEq(c.getPendingRequestCount(), 3);
+
+        uint256[] memory successfulRequestIds = new uint256[](3);
+        successfulRequestIds[0] = req1;
+        successfulRequestIds[1] = req2;
+        successfulRequestIds[2] = req3;
+        vm.prank(coa);
+        c.startProcessingBatch(successfulRequestIds, new uint256[](0));
+
+        for (uint256 i = 0; i < successfulRequestIds.length; i++) {
+            FlowYieldVaultsRequests.Request memory req = c.getRequest(successfulRequestIds[i]);
+            assertEq(uint8(req.status), uint8(FlowYieldVaultsRequests.RequestStatus.PROCESSING));
+        }
+        assertEq(c.getPendingRequestCount(), 0);
+    }
+
+    function test_UpgradeContract_RevertNonUUPS() public {
+        address nonUUPS = address(new MockDAI());  // any non-UUPS contract
+        vm.prank(c.owner());
+        vm.expectRevert(
+            abi.encodeWithSelector(ERC1967Utils.ERC1967InvalidImplementation.selector, nonUUPS)
+        );
+        c.upgradeToAndCall(nonUUPS, "");
+    }
+
+    function test_CannotReinitialize() public {
+        vm.expectRevert(Initializable.InvalidInitialization.selector);
+        c.initialize(coa, WFLOW);
+    }
+
+    function test_ImplementationCannotBeInitialized() public {
+        vm.expectRevert(Initializable.InvalidInitialization.selector);
+        impl.initialize(coa, WFLOW);
     }
 
     // ============================================
@@ -1118,8 +1203,13 @@ contract FlowYieldVaultsRequestsTest is Test {
     }
 
     function test_DeployWithZeroWFLOWAddress() public {
+        FlowYieldVaultsRequestsTestHelper fyvImpl = new FlowYieldVaultsRequestsTestHelper();
         // Deploy with address(0) for WFLOW - should work but not configure WFLOW
-        FlowYieldVaultsRequestsTestHelper contractNoWflow = new FlowYieldVaultsRequestsTestHelper(coa, address(0));
+        ERC1967Proxy fyvProxy = new ERC1967Proxy(
+            address(fyvImpl),
+            abi.encodeWithSignature("initialize(address,address)", coa, address(0))
+        );
+        FlowYieldVaultsRequestsTestHelper contractNoWflow = FlowYieldVaultsRequestsTestHelper(address(fyvProxy));
 
         // WFLOW at address(0) should NOT be supported
         (bool isSupported, , ) = contractNoWflow.allowedTokens(address(0));


### PR DESCRIPTION
Closes: https://github.com/onflow/FlowYieldVaultsEVM/issues/74
Closes: https://github.com/onflow/FlowYieldVaultsEVM/issues/75

***
Whenever we make any upgrades to the `FlowYieldVaultsRequests` Solidity contract, we have to be careful and update the [FlowYieldVaultsEVM](https://github.com/onflow/FlowYieldVaultsEVM/blob/main/cadence/contracts/FlowYieldVaultsEVM.cdc#L355-L360), to point to the proper smart contract address on EVM.

To simplify this step, we now use the `ERC1967Proxy`, and have the `FlowYieldVaultsRequests` be a `UUPSUpgradeable` implementation. This way, we only need to set the `FlowYieldVaultsEVM.flowYieldVaultsRequestsAddress` Cadence variable once, to point to the `ERC1967Proxy`.

This will also simplify any back-end/front-end apps, as only the `ERC1967Proxy` address will be necessary, and no updates will be needed there.

Some examples:
- `ERC1967Proxy` https://evm.flowscan.io/address/0x2880aB155794e7179c9eE2e38200202908C17B43 
- `UUPSUpgradeable` https://evm.flowscan.io/address/0xA2aa501b19aff244D90cc15a4Cf739D2725B5729

The `FlowYieldVaultsEVM` Cadence contract, continuously polls the `FlowYieldVaultsRequests` Solidity contract, to fetch pending requests, and process them. This makes the `FlowYieldVaultsRequests` contract a moving target, when it comes to updating it.

By having the `FlowYieldVaultsRequests` Solidity contract inherit from `UUPSUpgradeable`, and deploying it with `ERC1967Proxy`, we decouple the storage from the implementation logic. This means that all storage is now in `ERC1967Proxy` and the implementation only holds the `FlowYieldVaultsRequests` logic. If we need to do any logic updates on the implementation, we simply deploy a new `FlowYieldVaultsRequests` Solidity contract and we still preserve any pending user requests in `ERC1967Proxy`.